### PR TITLE
Fix relative link to banner image from org profile

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,6 @@
 ## Hello from the Tweag team!
 
-![Scale your engineering power](./banner.jpg)
+[![Scale your engineering power](/profile/banner.jpg)](https://tweag.io/)
 
 At Tweag we love using open source methods and research ideas to
 improve software quality and reliability. We are big on composable


### PR DESCRIPTION
This should hopefully fix the issue of the banner image not showing up when the org profile is rendered onto the org home page. The commit also makes the image link to tweag.io.